### PR TITLE
POC refactor

### DIFF
--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -5,6 +5,7 @@ namespace LineMob\Core\Command;
 use LineMob\Core\Input;
 use LineMob\Core\Storage\CommandStorageInterface;
 use LineMob\Core\Template\TemplateInterface;
+use LineMob\Core\Template\TextTemplate;
 
 /**
  * Class AbstractCommand
@@ -13,7 +14,7 @@ use LineMob\Core\Template\TemplateInterface;
  *
  * @property boolean $active
  * @property Input $input
- * @property TemplateInterface $message
+ * @property TemplateInterface|string $message
  * @property string $cmd
  * @property string $mode
  * @property array $tos
@@ -73,8 +74,17 @@ abstract class AbstractCommand implements \ArrayAccess, \JsonSerializable
      */
     public function offsetSet($offset, $value)
     {
-        if ('message' === $offset && !$value instanceof TemplateInterface) {
-            throw new \LogicException("The value of `message` key need to be instanceof ".TemplateInterface::class);
+        if ('message' === $offset) {
+            if (!$value instanceof TemplateInterface) {
+                $text = new TextTemplate();
+                $text->text = (string) $value;
+                $value = $text;
+            }
+
+            // still not!
+            if (!$value instanceof TemplateInterface) {
+                throw new \LogicException("The value of `message` key need to be instanceof ".TemplateInterface::class);
+            }
         }
 
         $this->data[$offset] = $value;

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -2,21 +2,19 @@
 
 namespace LineMob\Core\Command;
 
-use LineMob\Core\Constants;
 use LineMob\Core\Input;
 use LineMob\Core\Storage\CommandStorageInterface;
+use LineMob\Core\Template\TemplateInterface;
 
 /**
  * Class AbstractCommand
  *
  * @package LineMob\Handler
  *
- * @property boolean $actived
+ * @property boolean $active
  * @property Input $input
- * @property string $message
+ * @property TemplateInterface $message
  * @property string $cmd
- * @property string $emoticon
- * @property string $type
  * @property string $mode
  * @property array $tos
  * @property string $to
@@ -40,10 +38,6 @@ abstract class AbstractCommand implements \ArrayAccess, \JsonSerializable
     public function __construct(array $data = [])
     {
         $this->data = array_replace_recursive($this->data, $data);
-
-        if (!$this->type) {
-            $this->type = Constants::TYPE_TEXT;
-        }
     }
 
     /**
@@ -79,6 +73,10 @@ abstract class AbstractCommand implements \ArrayAccess, \JsonSerializable
      */
     public function offsetSet($offset, $value)
     {
+        if ('message' === $offset && !$value instanceof TemplateInterface) {
+            throw new \LogicException("The value of `message` key need to be instanceof ".TemplateInterface::class);
+        }
+
         $this->data[$offset] = $value;
     }
 
@@ -117,6 +115,7 @@ abstract class AbstractCommand implements \ArrayAccess, \JsonSerializable
             }
 
             array_push($this->data['logs'], $value);
+
             return;
         }
 

--- a/src/Doctrine/RegistryDecorator.php
+++ b/src/Doctrine/RegistryDecorator.php
@@ -59,9 +59,9 @@ class RegistryDecorator implements RegistryInterface
         $command = $this->decoratedRegistry->findCommand($input);
 
         if ($user = $this->findUser($input->userId)) {
-            if ($activedCmd = $user->getLineActivedCmd()) {
+            if ($activeCmd = $user->getLineActivedCmd()) {
                 $originText = $input->text;
-                $input->text = $activedCmd;
+                $input->text = $activeCmd;
 
                 // find previous command
                 $command = $this->decoratedRegistry->findCommand($input);

--- a/src/Factory/MessageFactory.php
+++ b/src/Factory/MessageFactory.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace LineMob\Core\Message;
+namespace LineMob\Core\Factory;
 
 use LineMob\Core\Command\AbstractCommand;
+use LineMob\Core\Message\MessageInterface;
 
-class Factory implements FactoryInterface
+class MessageFactory implements MessageFactoryInterface
 {
     /**
      * @var MessageInterface[]
@@ -31,10 +32,10 @@ class Factory implements FactoryInterface
     {
         foreach ($this->messages as $message) {
             if ($message->supported($command)) {
-                return $message->createTemplate($command);
+                return $message->createTemplate($command->message);
             }
         }
 
-        throw new \RuntimeException("Unsupported message type: ".$command->type);
+        throw new \RuntimeException("Unsupported message type: ".get_class($command->message));
     }
 }

--- a/src/Factory/MessageFactoryInterface.php
+++ b/src/Factory/MessageFactoryInterface.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace LineMob\Core\Message;
+namespace LineMob\Core\Factory;
 
 use LINE\LINEBot\MessageBuilder;
 use LineMob\Core\Command\AbstractCommand;
+use LineMob\Core\Message\MessageInterface;
 
-interface FactoryInterface
+interface MessageFactoryInterface
 {
     /**
      * @param MessageInterface $message

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LineMob\Core\Message;
+
+use LineMob\Core\Template\TemplateInterface;
+
+abstract class AbstractMessage implements MessageInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createTemplate(TemplateInterface $template)
+    {
+        return $template->getTemplate();
+    }
+}

--- a/src/Message/CarouselMessage.php
+++ b/src/Message/CarouselMessage.php
@@ -2,44 +2,16 @@
 
 namespace LineMob\Core\Message;
 
-use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselColumnTemplateBuilder;
-use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselTemplateBuilder;
-use LINE\LINEBot\TemplateActionBuilder\UriTemplateActionBuilder;
 use LineMob\Core\Command\AbstractCommand;
-use LineMob\Core\Constants;
+use LineMob\Core\Template\Carousel\CarouselTemplate;
 
-class CarouselMessage implements MessageInterface
+class CarouselMessage extends AbstractMessage
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function createTemplate(AbstractCommand $command)
-    {
-        $carousels = [];
-
-        foreach ($command['carousels'] as $carousel) {
-            $actions = [];
-
-            foreach ($carousel['actions'] as $action) {
-                $actions[] = new UriTemplateActionBuilder($action['label'], $action['link']);
-            }
-
-            $carousels[] = new CarouselColumnTemplateBuilder(
-                mb_substr($carousel['title'], 0, 40),
-                mb_substr($carousel['text'], 0, 60),
-                $carousel['thumbnail'],
-                $actions
-            );
-        }
-
-        return new CarouselTemplateBuilder($carousels);
-    }
-
     /**
      * {@inheritdoc}
      */
     public function supported(AbstractCommand $command)
     {
-        return Constants::TYPE_CAROUSEL == $command->type;
+        return $command->message instanceof CarouselTemplate;
     }
 }

--- a/src/Message/ImageMessage.php
+++ b/src/Message/ImageMessage.php
@@ -2,28 +2,16 @@
 
 namespace LineMob\Core\Message;
 
-use LINE\LINEBot\MessageBuilder\ImageMessageBuilder;
 use LineMob\Core\Command\AbstractCommand;
-use LineMob\Core\Constants;
+use LineMob\Core\Template\ImageTemplate;
 
-class ImageMessage implements MessageInterface
+class ImageMessage extends AbstractMessage
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function createTemplate(AbstractCommand $command)
-    {
-        $originalUrl = $command['originalUrl'];
-        $previewImageUrl = $command['previewImageUrl'];
-
-        return new ImageMessageBuilder($originalUrl, $previewImageUrl);
-    }
-
     /**
      * {@inheritdoc}
      */
     public function supported(AbstractCommand $command)
     {
-        return Constants::TYPE_IMAGE == $command->type;
+        return $command->message instanceof ImageTemplate;
     }
 }

--- a/src/Message/MessageInterface.php
+++ b/src/Message/MessageInterface.php
@@ -4,15 +4,16 @@ namespace LineMob\Core\Message;
 
 use LINE\LINEBot\MessageBuilder;
 use LineMob\Core\Command\AbstractCommand;
+use LineMob\Core\Template\TemplateInterface;
 
 interface MessageInterface
 {
     /**
-     * @param AbstractCommand $command
+     * @param TemplateInterface $template
      *
      * @return MessageBuilder
      */
-    public function createTemplate(AbstractCommand $command);
+    public function createTemplate(TemplateInterface $template);
 
     /**
      * @param AbstractCommand $command

--- a/src/Message/TextMessage.php
+++ b/src/Message/TextMessage.php
@@ -2,35 +2,16 @@
 
 namespace LineMob\Core\Message;
 
-use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
 use LineMob\Core\Command\AbstractCommand;
-use LineMob\Core\Constants;
+use LineMob\Core\Template\TextTemplate;
 
-class TextMessage implements MessageInterface
+class TextMessage extends AbstractMessage
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function createTemplate(AbstractCommand $command)
-    {
-        $message = $command->message;
-
-        if ($command->emoticon) {
-            $emoticon = substr($command->emoticon, 2);
-            $emoticon = hex2bin(str_repeat('0', 8 - strlen($emoticon)).$emoticon);
-            $emoticon = mb_convert_encoding($emoticon, 'UTF-8', 'UTF-32BE');
-
-            $message = sprintf("%s %s", $emoticon, $message);
-        }
-
-        return new TextMessageBuilder($message);
-    }
-
     /**
      * {@inheritdoc}
      */
     public function supported(AbstractCommand $command)
     {
-        return Constants::TYPE_TEXT == $command->type;
+        return $command->message instanceof TextTemplate;
     }
 }

--- a/src/Middleware/ClearActivedCmdMiddleware.php
+++ b/src/Middleware/ClearActivedCmdMiddleware.php
@@ -14,7 +14,7 @@ class ClearActivedCmdMiddleware implements Middleware
      */
     public function execute($command, callable $next)
     {
-        $command->actived = false;
+        $command->active = false;
 
         return $next($command);
     }

--- a/src/Middleware/DummyStorageConnectMiddleware.php
+++ b/src/Middleware/DummyStorageConnectMiddleware.php
@@ -17,7 +17,7 @@ class DummyStorageConnectMiddleware implements Middleware
     {
         // should find from real storage eg. mysql
         $command->storage = $storage = new CommandStorage();
-        $command->actived = $storage->getLineActivedCmd();
+        $command->active = $storage->getLineActivedCmd();
 
         $command->merge($storage->getLineCommandData());
 

--- a/src/Middleware/StoreActivedCmdMiddleware.php
+++ b/src/Middleware/StoreActivedCmdMiddleware.php
@@ -14,7 +14,7 @@ class StoreActivedCmdMiddleware implements Middleware
      */
     public function execute($command, callable $next)
     {
-        if ($command->actived) {
+        if ($command->active) {
             if (!$command->storage) {
                 throw new \RuntimeException("Require storage before using this middleware!");
             }

--- a/src/QuickStart.php
+++ b/src/QuickStart.php
@@ -8,9 +8,9 @@ use League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor;
 use League\Tactician\Handler\Locator\InMemoryLocator;
 use League\Tactician\Handler\MethodNameInflector\HandleInflector;
 use League\Tactician\Plugins\LockingMiddleware;
+use LineMob\Core\Factory\MessageFactory;
 use LineMob\Core\HttpClient\GuzzleHttpClient;
 use LineMob\Core\Message\CarouselMessage;
-use LineMob\Core\Message\Factory;
 use LineMob\Core\Message\ImageMessage;
 use LineMob\Core\Message\TextMessage;
 
@@ -59,7 +59,7 @@ class QuickStart
     public function setup($lineChannelToken, $lineChannelSecret, array $httpClientConfig = [])
     {
         $linebot = new LineBot(new GuzzleHttpClient($lineChannelToken, $httpClientConfig), ['channelSecret' => $lineChannelSecret]);
-        $factory = new Factory();
+        $factory = new MessageFactory();
         $registry = new Registry();
         $handler = new SenderHandler($linebot, $factory);
 

--- a/src/SenderHandler.php
+++ b/src/SenderHandler.php
@@ -3,7 +3,7 @@
 namespace LineMob\Core;
 
 use LineMob\Core\Command\AbstractCommand;
-use LineMob\Core\Message\FactoryInterface;
+use LineMob\Core\Factory\MessageFactoryInterface;
 
 class SenderHandler implements SenderHandlerInterface
 {
@@ -13,15 +13,15 @@ class SenderHandler implements SenderHandlerInterface
     protected $bot;
 
     /**
-     * @var FactoryInterface
+     * @var MessageFactoryInterface
      */
     protected $factory;
 
     /**
      * @param LineBot $bot
-     * @param FactoryInterface $factory
+     * @param MessageFactoryInterface $factory
      */
-    public function __construct(LineBot $bot, FactoryInterface $factory)
+    public function __construct(LineBot $bot, MessageFactoryInterface $factory)
     {
         $this->bot = $bot;
         $this->factory = $factory;

--- a/src/Template/AbstractTemplate.php
+++ b/src/Template/AbstractTemplate.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LineMob\Core\Template;
+
+abstract class AbstractTemplate implements TemplateInterface
+{
+    final public function __construct()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function jsonSerialize()
+    {
+        return $this;
+    }
+}

--- a/src/Template/Carousel/CarouselTemplate.php
+++ b/src/Template/Carousel/CarouselTemplate.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace LineMob\Core\Template\Carousel;
+
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselColumnTemplateBuilder;
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselTemplateBuilder;
+use LINE\LINEBot\TemplateActionBuilder\UriTemplateActionBuilder;
+use LineMob\Core\Template\AbstractTemplate;
+
+class CarouselTemplate extends AbstractTemplate
+{
+    /**
+     * @var Row[]
+     */
+    public $rows;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        $rows = [];
+
+        foreach ($this->rows as $row) {
+            $actions = [];
+
+            foreach ($row->actions as $action) {
+                $actions[] = new UriTemplateActionBuilder($action->label, $action->link);
+            }
+
+            $rows[] = new CarouselColumnTemplateBuilder(
+                mb_substr($row->title, 0, 40), mb_substr($row->text, 0, 60),
+                $row->thumbnail,
+                $actions
+            );
+        }
+
+        return new CarouselTemplateBuilder($rows);
+    }
+
+    /**
+     * @param string $title
+     * @param string $text
+     * @param string $thumbnail
+     * @param [{'label', 'link'}]|RowAction[] $actions
+     */
+    public function addRow($title, $text, $thumbnail, array $actions = [])
+    {
+        $this->rows[] = new Row($title, $text, $thumbnail, $actions);
+    }
+}

--- a/src/Template/Carousel/Row.php
+++ b/src/Template/Carousel/Row.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace LineMob\Core\Template\Carousel;
+
+class Row
+{
+    /**
+     * @var string
+     */
+    public $thumbnail;
+
+    /**
+     * @var string
+     */
+    public $text;
+
+    /**
+     * @var string
+     */
+    public $title;
+
+    /**
+     * @var RowAction[]
+     */
+    public $actions;
+
+    public function __construct($title, $text, $thumbnail, array $actions = [])
+    {
+        $this->label = $title;
+        $this->text = $text;
+        $this->thumbnail = $thumbnail;
+
+        foreach ($actions as $action) {
+            if (!$action instanceof RowAction) {
+                $action = new RowAction($action['label'], $action['link']);
+            }
+
+            $this->actions[] = $action;
+        }
+    }
+
+    /**
+     * @param $text
+     * @param $link
+     */
+    public function addAction($text, $link)
+    {
+        $this->actions[] = new RowAction($text, $link);
+    }
+}

--- a/src/Template/Carousel/RowAction.php
+++ b/src/Template/Carousel/RowAction.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LineMob\Core\Template\Carousel;
+
+class RowAction
+{
+    /**
+     * @var string
+     */
+    public $label;
+
+    /**
+     * @var string
+     */
+    public $link;
+
+    public function __construct($label, $link)
+    {
+        $this->label = $label;
+        $this->link = $link;
+    }
+}

--- a/src/Template/ImageTemplate.php
+++ b/src/Template/ImageTemplate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LineMob\Core\Template;
+
+use LINE\LINEBot\MessageBuilder\ImageMessageBuilder;
+
+class ImageTemplate extends AbstractTemplate
+{
+    /**
+     * @var string
+     */
+    public $originalUrl;
+
+    /**
+     * @var string
+     */
+    public $previewImageUrl;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        return new ImageMessageBuilder($this->originalUrl, $this->previewImageUrl);
+    }
+}

--- a/src/Template/TemplateInterface.php
+++ b/src/Template/TemplateInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace LineMob\Core\Template;
+
+use LINE\LINEBot\MessageBuilder;
+
+interface TemplateInterface extends \JsonSerializable
+{
+    /**
+     * @return MessageBuilder
+     */
+    public function getTemplate();
+}

--- a/src/Template/TextTemplate.php
+++ b/src/Template/TextTemplate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LineMob\Core\Template;
+
+use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
+
+class TextTemplate extends AbstractTemplate
+{
+    /**
+     * @var string
+     */
+    public $text;
+
+    /**
+     * @var string
+     */
+    public $emoticon;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        if ($this->emoticon) {
+            $emoticon = substr($this->emoticon, 2);
+            $emoticon = hex2bin(str_repeat('0', 8 - strlen($emoticon)).$emoticon);
+            $emoticon = mb_convert_encoding($emoticon, 'UTF-8', 'UTF-32BE');
+
+            $this->text = sprintf("%s %s", $emoticon, $this->text);
+        }
+
+        return new TextMessageBuilder($this->text);
+    }
+}


### PR DESCRIPTION
### Benefit
  - Testable
  - IDE autocomplete
  - Keep `src/Message` to be `service`
  - Clean client call, all of `src/Template` just simple class.

### Rule of Thumb
  - `JsonSerializable` Everything in `src/Template` need to be `JsonSerializable` that mean all properties should be `public` and there values should be friendly for `json_encode|json_decode`.

### Using sample
https://github.com/linemob/bot-sayhi/pull/2
https://github.com/linemob/bot-translation/pull/2